### PR TITLE
Implement remaining "TODOs" in PathTree

### DIFF
--- a/core/src/main/scala/org/http4s/rho/RuleExecutor.scala
+++ b/core/src/main/scala/org/http4s/rho/RuleExecutor.scala
@@ -6,17 +6,15 @@ import org.http4s.rho.bits.{ ResultResponse, SuccessResponse }
 
 import shapeless.{ HNil, HList }
 
-object RuleExecutor extends RuleExecutor
-
-sealed trait RuleExecutor {
+private[rho] trait RuleExecutor[F[_]] {
   //////////////////////// Stuff for executing the route //////////////////////////////////////
 
   /** Execute the rule tree */
-  def runRequestRules[F[_]](v: RequestRule[F], req: Request[F]): ResultResponse[F, HList] =
+  def runRequestRules(v: RequestRule[F], req: Request[F]): ResultResponse[F, HList] =
     runRequestRules(req, v, HNil)
 
   /** Executes the [[RequestRule]] tree pushing the results to `stack` */
-  def runRequestRules[F[_]](req: Request[F], v: RequestRule[F], stack: HList): ResultResponse[F, HList] = v match {
+  def runRequestRules(req: Request[F], v: RequestRule[F], stack: HList): ResultResponse[F, HList] = v match {
     case AndRule(a, b) => runRequestRules(req, a, stack).flatMap(runRequestRules(req, b, _))
     case OrRule(a, b) => runRequestRules(req, a, stack).orElse(runRequestRules(req, b, stack))
     case CaptureRule(reader) => reader(req).map(_::stack)

--- a/core/src/test/scala/org/http4s/rho/bits/PathTreeSpec.scala
+++ b/core/src/test/scala/org/http4s/rho/bits/PathTreeSpec.scala
@@ -12,6 +12,8 @@ import scodec.bits.ByteVector
 
 class PathTreeSpec extends Specification {
   import PathTree._
+  object pathTree extends PathTreeOps[IO]
+  import pathTree._
 
   "splitPath" should {
     "handle an empty string" in {
@@ -71,7 +73,7 @@ class PathTreeSpec extends Specification {
   }
 
   "PathTree mergers" >> {
-    val l = Leaf[IO]((r, b) => null)
+    val l = Leaf((r, b) => null)
 
     "MatchNodes" should {
       "Merge empty nodes" in {
@@ -100,7 +102,7 @@ class PathTreeSpec extends Specification {
       }
 
       "Merge non-empty intermediate nodes with non matching paths" in {
-        val endm: Map[Method, Leaf[IO]] = Map(Method.GET -> l)
+        val endm: Map[Method, Leaf] = Map(Method.GET -> l)
         val bar = MatchNode("bar", end = endm)
         val bizz = MatchNode("bizz", end = endm)
         val n1 = MatchNode("foo", matches = Map("bar" -> bar))
@@ -110,9 +112,9 @@ class PathTreeSpec extends Specification {
       }
 
       "Merge non-empty intermediate nodes with mixed matching paths" in {
-        val endm: Map[Method, Leaf[IO]] = Map(Method.GET -> l)
+        val endm: Map[Method, Leaf] = Map(Method.GET -> l)
         val bar = MatchNode("bar", end = endm)
-        val bizz = CaptureNode[IO](StringParser.booleanParser[IO], end = endm)
+        val bizz = CaptureNode(StringParser.booleanParser[IO], end = endm)
         val n1 = MatchNode("foo", matches = Map("bar" -> bar))
         val n2 = MatchNode("foo", captures = List(bizz))
 
@@ -148,7 +150,7 @@ class PathTreeSpec extends Specification {
       }
 
       "Merge non-empty intermediate nodes with non matching paths" in {
-        val endm: Map[Method, Leaf[IO]] = Map(Method.GET -> l)
+        val endm: Map[Method, Leaf] = Map(Method.GET -> l)
         val bar = MatchNode("bar", end = endm)
         val bizz = MatchNode("bizz", end = endm)
         val n1 = CaptureNode(p, matches = Map("bar" -> bar))
@@ -158,7 +160,7 @@ class PathTreeSpec extends Specification {
       }
 
       "Merge non-empty intermediate nodes with mixed matching paths" in {
-        val endm: Map[Method, Leaf[IO]] = Map(Method.GET -> l)
+        val endm: Map[Method, Leaf] = Map(Method.GET -> l)
         val bar = MatchNode("bar", end = endm)
         val bizz = CaptureNode(StringParser.booleanParser[IO], end = endm)
         val n1 = CaptureNode(p, matches = Map("bar" -> bar))
@@ -168,7 +170,7 @@ class PathTreeSpec extends Specification {
       }
 
       "Merging should preserve order" in {
-        val endm: Map[Method, Leaf[IO]] = Map(Method.GET -> l)
+        val endm: Map[Method, Leaf] = Map(Method.GET -> l)
         val bar = CaptureNode(StringParser.intParser[IO], end = endm)
         val bizz = CaptureNode(StringParser.booleanParser[IO], end = endm)
         val n1 = CaptureNode(p, captures = List(bar))
@@ -178,8 +180,8 @@ class PathTreeSpec extends Specification {
       }
 
       "Merging should promote order of the same nodes" in {
-        val end1: Map[Method, Leaf[IO]] = Map(Method.GET -> l)
-        val end2: Map[Method, Leaf[IO]] = Map(Method.POST -> l)
+        val end1: Map[Method, Leaf] = Map(Method.GET -> l)
+        val end2: Map[Method, Leaf] = Map(Method.POST -> l)
 
         val foo = CaptureNode(StringParser.shortParser[IO], end = end1)
         val bar = CaptureNode(StringParser.intParser[IO], end = end1)


### PR DESCRIPTION
Over the holidays I was working on upgrading rho to http4s 0.18 and ran into pretty much the same problems as you. At some point I gave up, but I see that you got it mostly working. I implemented the missing parts in `PathTree.scala` and the necessary changes triggered by them. It was just some types like `RouteResult[F, Response[F]]` that needed to be changed to `RouteResult[F, F[Response[F]]`.

Now it compiles, but we still have some failing tests in `TypeBuilderSpec` and `SwaggerModelsBuilderSpec`. 