### PR TITLE
fix test: IO.pure -> IO.apply

### DIFF
--- a/core/src/test/scala/org/http4s/rho/RhoServiceSpec.scala
+++ b/core/src/test/scala/org/http4s/rho/RhoServiceSpec.scala
@@ -71,7 +71,7 @@ class RhoServiceSpec extends Specification with RequestRunner {
 
     GET / "directTask" |>> {
       val i = new AtomicInteger(0)
-      IO.pure(s"${i.getAndIncrement}")
+      IO(s"${i.getAndIncrement}")
     }
 
     GET / "terminal" / "" |>> "terminal/"


### PR DESCRIPTION
This used do be a `Task.delay`, since the wrapped operation is not pure. 